### PR TITLE
Add scroll-to-top option in SetText() to prevent jitters.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -352,7 +352,7 @@ void TextEditor::Redo(int aSteps)
 		mUndoBuffer[mUndoIndex++].Redo(this);
 }
 
-void TextEditor::SetText(const std::string& aText)
+void TextEditor::SetText(const std::string& aText, bool ScrollToTop)
 {
 	mLines.clear();
 	mLines.emplace_back(Line());
@@ -369,7 +369,7 @@ void TextEditor::SetText(const std::string& aText)
 		}
 	}
 
-	mScrollToTop = true;
+	mScrollToTop = ScrollToTop;
 
 	mUndoBuffer.clear();
 	mUndoIndex = 0;

--- a/TextEditor.h
+++ b/TextEditor.h
@@ -87,7 +87,7 @@ public:
 	inline bool CanRedo() const { return !mReadOnly && mUndoIndex < (int)mUndoBuffer.size(); };
 	inline int GetUndoIndex() const { return mUndoIndex; };
 
-	void SetText(const std::string& aText);
+	void SetText(const std::string& aText, bool ScrollToTop=true);
 	std::string GetText() const;
 
 	void SetTextLines(const std::vector<std::string>& aLines);


### PR DESCRIPTION
This pull request allow imgui code browsing using `ImGuiColorTextEdit` when used as a submodule in the `imgui_bundle` project.

To enable this, I added an option to prevent scroll-to-top when we set text. This prevents jitters.

This PR is related to the following PRs across all submodules of `imgui_bundle`:
1. pthom/imgui_bundle - `main` branch - [Link to PR](https://github.com/pthom/imgui_bundle/pull/323)
2. pthom/imgui - `imgui_bundle` branch - [Link to PR](https://github.com/pthom/imgui/pull/1)
3. pthom/ImGuiColorTextEdit - `imgui_bundle` branch - (This PR)



